### PR TITLE
add cache lens and env extraction lens

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: bun-test
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
+jobs:
+  my-job:
+    name: bun-test
+    runs-on: ubuntu-latest
+    steps:
+      # ...
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+
+      # run any `bun` or `bunx` command
+      - run: bun install
+      - run: bun test
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rdf-lens",
-  "version": "1.1.2",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rdf-lens",
-      "version": "1.1.2",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdf-lens",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "./dist/index.js",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "rdf-lens",
-  "version": "1.1.3",
+  "version": "1.2.2",
   "main": "./dist/index.js",
   "type": "module",
   "exports": {
     "import": "./dist/index.js",
     "require": "./dist/index.cjs"
   },
+  "files": [
+    "./dist/**/*"
+  ],
   "description": "",
   "scripts": {
     "build": "tsc && rollup  ./dist/index.js --file ./dist/index.cjs --format cjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export * from "./lens";
-export * as shacl from "./shacl";
+export * from "./shacl";

--- a/src/lens.ts
+++ b/src/lens.ts
@@ -1,42 +1,46 @@
 import type { Quad, Term } from "@rdfjs/types";
 
-
 export type Cont<Q = Term> = { id: Q; quads: Quad[] };
 export type Res<T> = [Term, T];
 
+let lensIndex = 0;
+
 export class BasicLens<C, T> {
-  _exec: (container: C) => T;
-  constructor(execute: (container: C) => T) {
+  _exec: (container: C, state: any, states: any[]) => T;
+  index: number;
+  constructor(execute: (container: C, state: any, states: any[]) => T) {
     this._exec = execute;
+    this.index = lensIndex;
+    lensIndex += 1;
   }
 
   asMulti(): T extends any[] ? BasicLensM<C, T[number]> : never {
-    return <T extends any[] ? BasicLensM<C, T[number]> : never> new BasicLensM(
-      (c) => {
-        const out = this.execute(c);
-        return <T extends any[] ? any[] : never> out;
-      },
+    return <T extends any[] ? BasicLensM<C, T[number]> : never>(
+      new BasicLensM((c, _, states) => {
+        const out = this.execute(c, states);
+        return <T extends any[] ? any[] : never>out;
+      })
     );
   }
 
   and<F extends any[]>(
     ...and: { [K in keyof F]: BasicLens<C, F[K]> }
   ): BasicLens<C, [T, ...{ [K in keyof F]: F[K] }]> {
-    return <BasicLens<C, [T, ...{ [K in keyof F]: F[K] }]>> new BasicLens(
-      (c) => {
-        const a = this.execute(c);
-        const rest: F = <any> and.map((x) => x.execute(c));
+    return <BasicLens<C, [T, ...{ [K in keyof F]: F[K] }]>>(
+      new BasicLens((c, _, states) => {
+        const a = this.execute(c, states);
+        const rest: F = <any>and.map((x) => x.execute(c, states));
         return [a, ...rest];
-      },
+      })
     );
   }
 
   orM(...others: BasicLens<C, T>[]): BasicLensM<C, T> {
-    return new BasicLensM((c) => {
+    return new BasicLensM((c, _, states) => {
       const all = [this, ...others];
       return all.flatMap((x) => {
         try {
-          return [x.execute(c)];
+          return [x.execute(c, states)];
         } catch (ex: any) {
           return [];
         }
@@ -44,18 +48,15 @@ export class BasicLens<C, T> {
     });
   }
 
-  or(
-    ...others: BasicLens<C, T>[]
-  ): BasicLens<C, T> {
-    return new BasicLens((c) => {
+  or(...others: BasicLens<C, T>[]): BasicLens<C, T> {
+    return new BasicLens((c, _, states) => {
       try {
-        return this.execute(c);
+        return this.execute(c, states);
       } catch (ex: any) {
         for (let i = 0; i < others.length; i++) {
           try {
-            return others[i].execute(c);
-          } catch (ex) {
-          }
+            return others[i].execute(c, states);
+          } catch (ex) {}
         }
       }
       throw "nope";
@@ -63,47 +64,48 @@ export class BasicLens<C, T> {
   }
 
   map<F>(fn: (t: T) => F): BasicLens<C, F> {
-    return new BasicLens((c) => {
-      const a = this.execute(c);
+    return new BasicLens((c, _, states) => {
+      const a = this.execute(c, states);
       return fn(a);
     });
   }
 
-  then<F>(
-    next: BasicLens<T, F>,
-  ): BasicLens<C, F> {
-    return new BasicLens((c) => {
-      const a = this.execute(c);
-      return next.execute(a);
+  then<F>(next: BasicLens<T, F>): BasicLens<C, F> {
+    return new BasicLens((c, _, states) => {
+      const a = this.execute(c, states);
+      return next.execute(a, states);
     });
   }
 
-  execute(container: C): T {
-    return this._exec(container);
+  execute(container: C, states: any[] = []): T {
+    if (!states[this.index]) {
+      states[this.index] = {};
+    }
+    return this._exec(container, states[this.index], states);
   }
 }
 
 export class BasicLensM<C, T> extends BasicLens<C, T[]> {
   one<D = T>(def?: D): BasicLens<C, T | D> {
-    return new BasicLens((c) => {
-      const qs = this.execute(c);
+    return new BasicLens((c, _, states) => {
+      const qs = this.execute(c, states);
       return qs[0] || def!;
     });
   }
   expectOne(): BasicLens<C, T> {
-    return new BasicLens((c) => {
-      const qs = this.execute(c);
+    return new BasicLens((c, _, states) => {
+      const qs = this.execute(c, states);
       if (qs.length < 1) throw "Nope";
       return qs[0];
     });
   }
 
   thenAll<F>(next: BasicLens<T, F>): BasicLensM<C, F> {
-    return new BasicLensM((c) => {
-      const qs = this.execute(c);
+    return new BasicLensM((c, _, states) => {
+      const qs = this.execute(c, states);
       return qs.flatMap((x) => {
         try {
-          const o = next.execute(x);
+          const o = next.execute(x, states);
           return [o];
         } catch (ex: any) {
           return [];
@@ -116,32 +118,28 @@ export class BasicLensM<C, T> extends BasicLens<C, T[]> {
   }
 
   thenFlat<F>(next: BasicLensM<T, F>): BasicLensM<C, F> {
-    return new BasicLensM((c) => {
-      const qs = this.execute(c);
-      return qs.flatMap((x) => next.execute(x));
+    return new BasicLensM((c, _, states) => {
+      const qs = this.execute(c, states);
+      return qs.flatMap((x) => next.execute(x, states));
     });
   }
   mapAll<F>(fn: (t: T) => F): BasicLensM<C, F> {
-    return new BasicLensM((c) => {
-      const qs = this.execute(c);
+    return new BasicLensM((c, _, states) => {
+      const qs = this.execute(c, states);
       return qs.map(fn);
     });
   }
 
-  orAll(
-    ...others: BasicLensM<C, T>[]
-  ): BasicLensM<C, T> {
-    return new BasicLensM((c) => {
+  orAll(...others: BasicLensM<C, T>[]): BasicLensM<C, T> {
+    return new BasicLensM((c, _, states) => {
       let out = [];
       try {
-        out.push(...this.execute(c));
-      } catch (ex: any) {
-      }
+        out.push(...this.execute(c, states));
+      } catch (ex: any) {}
       for (let i = 0; i < others.length; i++) {
         try {
-          out.push(...others[i].execute(c));
-        } catch (ex: any) {
-        }
+          out.push(...others[i].execute(c, states));
+        } catch (ex: any) {}
       }
 
       return out;
@@ -149,38 +147,35 @@ export class BasicLensM<C, T> extends BasicLens<C, T[]> {
   }
 
   filter(fn: (object: T) => boolean): BasicLensM<C, T> {
-    return new BasicLensM((c) => {
-      return this.execute(c).filter(fn);
+    return new BasicLensM((c, _, states) => {
+      return this.execute(c, states).filter(fn);
     });
   }
 }
 
 export function pred(pred?: Term): BasicLensM<Cont, Cont> {
   return new BasicLensM(({ quads, id }) => {
-    const out = quads
-      .filter((q) =>
-        q.subject.equals(id) && (!pred || q.predicate.equals(pred))
-      );
+    const out = quads.filter(
+      (q) => q.subject.equals(id) && (!pred || q.predicate.equals(pred)),
+    );
     return out.map((q) => ({ quads, id: q.object }));
   });
 }
 
 export function invPred(pred?: Term): BasicLensM<Cont, Cont> {
   return new BasicLensM(({ quads, id }) => {
-    const out = quads
-      .filter((q) =>
-        q.object.equals(id) && (!pred || q.predicate.equals(pred))
-      );
+    const out = quads.filter(
+      (q) => q.object.equals(id) && (!pred || q.predicate.equals(pred)),
+    );
     return out.map((q) => ({ quads, id: q.subject }));
   });
 }
 
 export function predTriple(pred?: Term): BasicLensM<Cont, Cont<Quad>> {
   return new BasicLensM(({ quads, id }) => {
-    const out = quads
-      .filter((q) =>
-        q.subject.equals(id) && (!pred || q.predicate.equals(pred))
-      );
+    const out = quads.filter(
+      (q) => q.subject.equals(id) && (!pred || q.predicate.equals(pred)),
+    );
     return out.map((q) => ({ quads, id: q }));
   });
 }
@@ -216,36 +211,38 @@ export function match(
   object: Term | undefined,
 ): BasicLensM<Quad[], Cont<Quad>> {
   return new BasicLensM((quads) => {
-    return quads.filter((x) =>
-      (!subject || x.subject.equals(subject)) &&
-      (!predicate || x.predicate.equals(predicate)) &&
-      (!object || x.object.equals(object))
-    ).map((id) => ({ id, quads }));
+    return quads
+      .filter(
+        (x) =>
+          (!subject || x.subject.equals(subject)) &&
+          (!predicate || x.predicate.equals(predicate)) &&
+          (!object || x.object.equals(object)),
+      )
+      .map((id) => ({ id, quads }));
   });
 }
 
-export const subject: BasicLens<Cont<Quad>, Cont> = new BasicLens((
-  { id, quads },
-) => ({
-  id: id.subject,
-  quads,
-}));
+export const subject: BasicLens<Cont<Quad>, Cont> = new BasicLens(
+  ({ id, quads }) => ({
+    id: id.subject,
+    quads,
+  }),
+);
 
-export const predicate: BasicLens<Cont<Quad>, Cont> = new BasicLens((
-  { id, quads },
-) => ({
-  id: id.predicate,
-  quads,
-}));
+export const predicate: BasicLens<Cont<Quad>, Cont> = new BasicLens(
+  ({ id, quads }) => ({
+    id: id.predicate,
+    quads,
+  }),
+);
 
-export const object: BasicLens<Cont<Quad>, Cont> = new BasicLens((
-  { id, quads },
-) => ({
-  id: id.object,
-  quads,
-}));
+export const object: BasicLens<Cont<Quad>, Cont> = new BasicLens(
+  ({ id, quads }) => ({
+    id: id.object,
+    quads,
+  }),
+);
 
 export function empty<C>(): BasicLens<C, C> {
   return new BasicLens((x) => x);
 }
-

--- a/src/ontology.ts
+++ b/src/ontology.ts
@@ -37,4 +37,7 @@ export const RDFL = createUriAndTermNamespace(
   "PathLens",
   "Context",
   "TypedExtract",
+  "EnvVariable",
+  "envKey",
+  "envDefault"
 );

--- a/test/shacl2.test.ts
+++ b/test/shacl2.test.ts
@@ -26,6 +26,7 @@ ${prefixes}
     sh:path js:z;
     sh:name "z";
     sh:maxCount 1;
+    sh:minCount 1;
   ].
 
 js:3DPoint rdfs:subClassOf js:Point.
@@ -74,6 +75,7 @@ js:JsProcessorShape a sh:NodeShape;
     sh:class rdfl:TypedExtract;
     sh:name "dataPoint";
     sh:maxCount 1;
+    sh:minCount 1;
   ].
 `;
 
@@ -168,9 +170,10 @@ ${prefixes}
       id: quad.subject,
       quads,
     });
-    expect(object.dataPoint.z).toBe(64);
+
     expect(object.dataPoint.x).toBe(5);
     expect(object.dataPoint.y).toBe(42);
+    expect(object.dataPoint.z).toBe(64);
   });
 
   test("Parse objects without type", () => {
@@ -376,7 +379,7 @@ ${prefixes}
     const obj = output.lenses[quad.object.value].execute({
       id: quad.subject,
       quads,
-    });
+    }, []);
 
     test("Shapes contain rdfl lenses", () => {
       const shapes = Object.keys(output.lenses);


### PR DESCRIPTION
Add cached lenses.
For this, the execute function has been changed to keep track of the states of all lenses.
This is required and cannot be a Lens specific variable or global variable because the cache should be renewed for each execution of the lens.