### PR TITLE
feat: support sh:defaultValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,54 @@ Note: `sh:datatype` is used for literals, `sh:class` is used for objects.
 
 * `sh:minCount` tells rdf-lens that this property is required, and will fail to parse an object that does not adhere to the shape.
 * `sh:maxCount` tells rdf-lens whether or not to expect multiple objects. If this is not set or is bigger than 1, the Javascript object will have an array as its value.
+* `sh:defaultValue` tells rdf-lens what to use when the data has no value for this property. A default satisfies `sh:minCount`, so a required property with a default never fails to parse.
+
+**Default values** are extracted the same way the data would have been, but from the shapes graph:
+
+```turtle
+[] a sh:NodeShape;
+  sh:targetClass <Me>;
+  sh:property [
+    sh:name "name";
+    sh:path <name>;
+    sh:datatype xsd:string;
+    sh:defaultValue "ajuvercr";   # A literal is converted with sh:datatype
+    sh:maxCount 1;
+    sh:minCount 1;
+  ], [
+    sh:name "age";
+    sh:path <age>;
+    sh:datatype xsd:integer;
+    sh:maxCount 1;
+    sh:minCount 1;
+  ].
+```
+
+```turtle
+<foobar> a <Me>;
+  <age> 95.
+```
+
+extracts to `{ "name": "ajuvercr", "age": 95 }`.
+
+For a `sh:class` property the default is a node, and it is extracted through that class's shape. Its own properties are read from the shapes graph, and whatever it leaves out falls back to the defaults of that shape in turn:
+
+```turtle
+[] a sh:NodeShape;
+  sh:targetClass <Friend>;
+  sh:property [
+    sh:name "friend";
+    sh:path <friend>;
+    sh:class <Me>;
+    sh:defaultValue [ <age> 95 ];   # <name> comes from the Me shape default
+    sh:maxCount 1;
+    sh:minCount 1;
+  ].
+```
+
+`<foobar> a <Friend>.` extracts to `{ "friend": { "name": "ajuvercr", "age": 95 } }`. The same happens one level down: a friend that is present in the data but has no `<name>` still gets `"ajuvercr"`.
+
+For a property that holds multiple values, the default may be a single value or an RDF list, and it is only used when the data has no values at all.
 
 
 

--- a/src/shacl.ts
+++ b/src/shacl.ts
@@ -40,6 +40,12 @@ export interface ShapeField {
     minCount?: number;
     maxCount?: number;
     extract: BasicLens<Cont, unknown>;
+    /**
+     * The sh:defaultValue node, used when the data has no value for this field.
+     * It points into the shapes graph rather than the data, so extracting it
+     * reads the default's own properties (`sh:defaultValue [ ex:age 95 ]`).
+     */
+    defaultValue?: Cont;
 }
 
 /**
@@ -55,35 +61,52 @@ export interface Shape {
 function fieldToLens(field: ShapeField): BasicLens<Cont, unknown> {
     const minCount = field.minCount || 0;
     const maxCount = field.maxCount || Number.MAX_SAFE_INTEGER;
-    if (maxCount < 2) {
-        return field.path.one(undefined).then(
-            new BasicLens((x, ctx) => {
-                if (x) {
-                    return field.extract.execute(x, ctx);
-                } else {
-                    if (minCount > 0) {
-                        throw new LensError(
-                            "Field is not defined and required",
-                            ctx.lineage.slice(),
-                        );
-                    } else {
-                        return x;
-                    }
-                }
-            }),
-        );
-    }
-    if (maxCount < 2) return field.path.one().then(field.extract);
 
     const thenListExtract = RdfList.and(empty<Cont>()).map(
         ([terms, { quads }]) => terms.map((id) => ({ id, quads })),
     );
     const noListExtract = empty<Cont>().map((x) => [x]);
 
+    // The default is extracted like any other value, but from the container it
+    // was defined in: the shapes graph. So a literal goes through the same
+    // datatype conversion, and a node through the same class lens, picking up
+    // that shape's own defaults in turn.
+    const defaults = thenListExtract
+        .or(noListExtract)
+        .asMulti()
+        .thenAll(field.extract);
+    const extractDefault = (ctx: LensContext): unknown[] | undefined =>
+        field.defaultValue && defaults.execute(field.defaultValue, ctx);
+
+    if (maxCount < 2) {
+        return field.path.one(undefined).then(
+            new BasicLens((x, ctx) => {
+                if (x) {
+                    return field.extract.execute(x, ctx);
+                }
+
+                const def = extractDefault(ctx);
+                if (def && def.length > 0) {
+                    return def[0];
+                }
+
+                if (minCount > 0) {
+                    throw new LensError(
+                        "Field is not defined and required",
+                        ctx.lineage.slice(),
+                    );
+                } else {
+                    return x;
+                }
+            }),
+        );
+    }
+
     return field.path
         .thenFlat(thenListExtract.or(noListExtract).asMulti())
         .thenAll(field.extract)
         .map((x) => x.filter((x) => x !== undefined))
+        .map((xs, ctx) => (xs.length === 0 ? (extractDefault(ctx) ?? xs) : xs))
         .map((xs, ctx) => {
             if (xs.length < minCount) {
                 throw new LensError("Mininum Count violation", [
@@ -579,6 +602,14 @@ function extractProperty(
     const minCount = optionalField(SHACL.minCount, "minCount", (x) => +x);
     const maxCount = optionalField(SHACL.maxCount, "maxCount", (x) => +x);
 
+    // Keep the container, not just the term: the default may be a node whose
+    // properties live in the shapes graph, and those quads travel with it.
+    const defaultValueLens: BasicLens<Cont, { defaultValue?: Cont }> = pred(
+        SHACL.defaultValue,
+    )
+        .one(undefined)
+        .map((defaultValue) => (defaultValue ? { defaultValue } : {}));
+
     const dataTypeLens: BasicLens<Cont, { extract: ShapeField["extract"] }> =
         pred(SHACL.datatype)
             .one()
@@ -616,7 +647,13 @@ function extractProperty(
         });
 
     return pathLens
-        .and(nameLens, minCount, maxCount, clazzLens.or(dataTypeLens))
+        .and(
+            nameLens,
+            minCount,
+            maxCount,
+            defaultValueLens,
+            clazzLens.or(dataTypeLens),
+        )
         .map((xs) => Object.assign({}, ...xs));
 }
 

--- a/test/default-value.test.ts
+++ b/test/default-value.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, test } from "vitest";
+import { Parser } from "n3";
+import { RDF } from "@treecg/types";
+import { extractShapes } from "../src/shacl";
+
+const prefixes = `
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex: <http://example.org/> .
+@prefix rdfl: <https://w3id.org/rdf-lens/ontology#> .
+`;
+
+const parse = (turtle: string) => new Parser().parse(prefixes + turtle);
+
+/**
+ * Extracts the single typed subject of the data through the shape defined for
+ * its rdf:type, the way a consumer of extractShapes would.
+ */
+function extract(shapes: string, data: string): Record<string, unknown> {
+    const output = extractShapes(parse(shapes));
+    const quads = parse(data);
+    const typeQuad = quads.find((x) => x.predicate.equals(RDF.terms.type))!;
+
+    return <Record<string, unknown>>output.lenses[
+        typeQuad.object.value
+    ].execute({
+        id: typeQuad.subject,
+        quads,
+    });
+}
+
+describe("sh:defaultValue", () => {
+    const meShape = `
+[] a sh:NodeShape;
+  sh:targetClass ex:Me;
+  sh:property [
+    sh:name "name";
+    sh:path ex:name;
+    sh:minCount 1;
+    sh:maxCount 1;
+    sh:datatype xsd:string;
+    sh:defaultValue "ajuvercr";
+  ], [
+    sh:name "age";
+    sh:path ex:age;
+    sh:minCount 1;
+    sh:maxCount 1;
+    sh:datatype xsd:integer;
+  ].
+`;
+
+    test("Missing value falls back to the default", () => {
+        const object = extract(
+            meShape,
+            `
+<foobar> a ex:Me;
+  ex:age 95.
+`,
+        );
+
+        expect(object).toEqual({ name: "ajuvercr", age: 95 });
+    });
+
+    test("Present value wins over the default", () => {
+        const object = extract(
+            meShape,
+            `
+<foobar> a ex:Me;
+  ex:name "semssie";
+  ex:age 95.
+`,
+        );
+
+        expect(object).toEqual({ name: "semssie", age: 95 });
+    });
+
+    test("Default is converted with the declared datatype", () => {
+        const object = extract(
+            `
+[] a sh:NodeShape;
+  sh:targetClass ex:Me;
+  sh:property [
+    sh:name "age";
+    sh:path ex:age;
+    sh:maxCount 1;
+    sh:datatype xsd:integer;
+    sh:defaultValue 42;
+  ], [
+    sh:name "member";
+    sh:path ex:member;
+    sh:maxCount 1;
+    sh:datatype xsd:boolean;
+    sh:defaultValue "true";
+  ].
+`,
+            "<foobar> a ex:Me.",
+        );
+
+        expect(object).toEqual({ age: 42, member: true });
+    });
+
+    test("A missing value without a default is still an error when required", () => {
+        expect(() =>
+            extract(
+                meShape,
+                `
+<foobar> a ex:Me.
+`,
+            ),
+        ).toThrow();
+    });
+
+    test("Default may be an environment variable", () => {
+        process.env["RDF_LENS_TEST_NAME"] = "from the environment";
+
+        const object = extract(
+            `
+[] a sh:NodeShape;
+  sh:targetClass ex:Me;
+  sh:property [
+    sh:name "name";
+    sh:path ex:name;
+    sh:maxCount 1;
+    sh:datatype xsd:string;
+    sh:defaultValue [
+      a rdfl:EnvVariable;
+      rdfl:envKey "RDF_LENS_TEST_NAME";
+      rdfl:envDefault "unset";
+    ];
+  ].
+`,
+            "<foobar> a ex:Me.",
+        );
+
+        expect(object).toEqual({ name: "from the environment" });
+    });
+
+    describe("nested shapes", () => {
+        const friendShape = (defaultValue: string) => `
+${meShape}
+
+[] a sh:NodeShape;
+  sh:targetClass ex:Friend;
+  sh:property [
+    sh:name "friend";
+    sh:path ex:friend;
+    sh:class ex:Me;
+    sh:minCount 1;
+    sh:maxCount 1;
+    sh:defaultValue ${defaultValue};
+  ].
+`;
+
+        test("Default node is extracted through the class shape", () => {
+            const object = extract(
+                friendShape("[ a ex:Me; ex:age 95 ]"),
+                "<foobar> a ex:Friend.",
+            );
+
+            expect(object).toEqual({
+                friend: { name: "ajuvercr", age: 95 },
+            });
+        });
+
+        test("Default node does not need an rdf:type", () => {
+            const object = extract(
+                friendShape("[ ex:age 95 ]"),
+                "<foobar> a ex:Friend.",
+            );
+
+            expect(object).toEqual({
+                friend: { name: "ajuvercr", age: 95 },
+            });
+        });
+
+        test("Properties of the default node win over the nested defaults", () => {
+            const object = extract(
+                friendShape(`
+[ ex:name "semssie"; ex:age 94 ]
+`),
+                "<foobar> a ex:Friend.",
+            );
+
+            expect(object).toEqual({
+                friend: { name: "semssie", age: 94 },
+            });
+        });
+
+        test("Defaults apply inside a node that is present in the data", () => {
+            const object = extract(
+                friendShape("[ ex:age 95 ]"),
+                `
+<foobar> a ex:Friend;
+  ex:friend [
+    ex:age 95;
+  ].
+`,
+            );
+
+            expect(object).toEqual({
+                friend: { name: "ajuvercr", age: 95 },
+            });
+        });
+    });
+
+    describe("multi valued fields", () => {
+        const listShape = (defaultValue: string) => `
+[] a sh:NodeShape;
+  sh:targetClass ex:Me;
+  sh:property [
+    sh:name "nicknames";
+    sh:path ex:nickname;
+    sh:datatype xsd:string;
+    sh:defaultValue ${defaultValue};
+  ].
+`;
+
+        test("Empty field falls back to a single default", () => {
+            const object = extract(
+                listShape(`
+"ajuvercr"
+`),
+                "<foobar> a ex:Me.",
+            );
+
+            expect(object).toEqual({ nicknames: ["ajuvercr"] });
+        });
+
+        test("Empty field falls back to a default rdf list", () => {
+            const object = extract(
+                listShape(`
+( "ajuvercr" "semssie" )
+`),
+                "<foobar> a ex:Me.",
+            );
+
+            expect(object).toEqual({ nicknames: ["ajuvercr", "semssie"] });
+        });
+
+        test("Values in the data suppress the default entirely", () => {
+            const object = extract(
+                listShape(`
+( "ajuvercr" "semssie" )
+`),
+                `
+<foobar> a ex:Me;
+  ex:nickname "arthur".
+`,
+            );
+
+            expect(object).toEqual({ nicknames: ["arthur"] });
+        });
+    });
+});


### PR DESCRIPTION
A property with a sh:defaultValue falls back to that value when the data has none, which also satisfies sh:minCount - a required property with a default no longer fails to parse.

The default is kept as a container, not a bare term, so the quads it was defined in travel with it. That is what makes nested defaults work: a sh:class property whose default is a node has that node extracted through the class shape, reading its properties out of the shapes graph, and whatever it leaves unset falls back to that shape's own defaults in turn. The same recursion applies to a node that does exist in the data but is missing a field.

Because the default goes through the field's own extract lens, literals are converted with sh:datatype and rdfl:EnvVariable nodes resolve against the environment, both for free.

For a multi valued property the default may be a single value or an RDF list, and only applies when the data has no values at all.

Closes #28